### PR TITLE
Fixed `find-midi-device` for Windows, improved device type checking 

### DIFF
--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -89,11 +89,12 @@
 (defn find-midi-device [^String device-name device-type]
   (let [devices (list-midi-devices)
         found (filter 
-                #(and (>= (.indexOf ^String (:description %) device-name) 0) 
-                (if (= :in device-type)  
-                  (>= (.getMaxReceivers ^MidiDevice (:device %) ) 0)
-                  (>= (.getMaxTransmitters ^MidiDevice (:device %) ) 0)
-                  ))
+                #(and (or (>= (.indexOf ^String (:description %) device-name) 0)
+                          (>= (.indexOf ^String (:name %) device-name) 0)) 
+                      (if (= :in device-type)  
+                        (>= (.getMaxReceivers ^MidiDevice (:device %) ) 0)
+                        (>= (.getMaxTransmitters ^MidiDevice (:device %) ) 0)
+                        ))
                 devices)
 
         num-found (count found)]

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -89,12 +89,14 @@
 (defn find-midi-device [^String device-name device-type]
   (let [devices (list-midi-devices)
         found (filter 
-                #(and (or (>= (.indexOf ^String (:description %) device-name) 0)
-                          (>= (.indexOf ^String (:name %) device-name) 0)) 
-                      (if (= :in device-type)  
-                        (>= (.getMaxReceivers ^MidiDevice (:device %) ) 0)
-                        (>= (.getMaxTransmitters ^MidiDevice (:device %) ) 0)
-                        ))
+                (fn [{:keys [^String description 
+                             ^String name 
+                             ^MidiDevice device]}] 
+                  (and (or (>= (.indexOf description device-name) 0)
+                           (>= (.indexOf name device-name) 0)) 
+                       (if (= :in device-type)
+                         (>= (.getMaxReceivers device) 0)
+                         (>= (.getMaxTransmitters device) 0))))
                 devices)
 
         num-found (count found)]

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -89,14 +89,12 @@
 (defn find-midi-device [^String device-name device-type]
   (let [devices (list-midi-devices)
         found (filter 
-                (fn [{:keys [^String description 
-                             ^String name 
-                             ^MidiDevice device]}] 
+                (fn [{:keys [^String description ^String name] :as device}] 
                   (and (or (>= (.indexOf description device-name) 0)
                            (>= (.indexOf name device-name) 0)) 
                        (if (= :in device-type)
-                         (>= (.getMaxReceivers device) 0)
-                         (>= (.getMaxTransmitters device) 0))))
+                         (midi-input-device? device)
+                         (midi-output-device? device))))
                 devices)
 
         num-found (count found)]
@@ -108,7 +106,7 @@
                   (map #(str "\t" (:name %) ": " (:description %) "\n"))
                   (apply str "Multiple devices found (" num-found 
                          ") matching name: " device-name "\n")
-                  Exception.)
+                  Exception.))
       :else (first found))))
 
 

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -102,9 +102,13 @@
         num-found (count found)]
     (cond
       (<= num-found 0) 
-      (throw (Exception. "No devices found"))
+      (throw (Exception. (str "No MIDI devices found matching name: " device-name)))
       (> num-found 1) 
-      (throw (Exception. (format "Multiple devices found (%d)." num-found)))
+      (throw (->> found
+                  (map #(str "\t" (:name %) ": " (:description %) "\n"))
+                  (apply str "Multiple devices found (" num-found 
+                         ") matching name: " device-name "\n")
+                  Exception.)
       :else (first found))))
 
 


### PR DESCRIPTION
Made `find-midi-device` function on Windows. #3 

Made checking that device is of correct type work. #4 

Tidied code a touch.

