### PR TITLE
Use more idiomatic naming in `pink.io.midi`

### DIFF
--- a/src/demo/pink/demo/midi.clj
+++ b/src/demo/pink/demo/midi.clj
@@ -1,6 +1,6 @@
 (ns pink.demo.midi
   (:require [pink.simple :refer :all] 
-            [pink.io.midi :refer :all]
+            [pink.io.midi :as midi]
             [pink.config :refer :all]
             [pink.space :refer :all]
             [pink.oscillators :refer [oscili]]
@@ -12,15 +12,15 @@
 
 (comment
 
-  (def midim (create-midi-manager))
-  (def sliders (add-virtual-device midim "slider/knobs 1")) 
-  (def keyboard (add-virtual-device midim "keyboard 1")) 
+  (def midim (midi/create-manager))
+  (def sliders (midi/add-virtual-device midim "slider/knobs 1")) 
+  (def keyboard (midi/add-virtual-device midim "keyboard 1")) 
 
-  (bind-device midim "nanoKONTROL SLIDER/KNOB" "slider/knobs 1")
+  (midi/bind-device midim "nanoKONTROL SLIDER/KNOB" "slider/knobs 1")
 
   ;(midi-device-debug "nanoKONTROL SLIDER/KNOB")
 
-  (def get-cc (partial get-midi-cc-atom sliders 0))
+  (def get-cc (partial midi/get-cc-atom sliders 0))
 
 
   (defn midi-atom-reader

--- a/src/demo/pink/demo/midi_debug.clj
+++ b/src/demo/pink/demo/midi_debug.clj
@@ -1,13 +1,13 @@
 (ns pink.demo.midi-debug
-  (:require [pink.io.midi :refer :all]))
+  (:require [pink.io.midi :as midi]))
 
 (comment 
-  (list-midi-devices)
-  (list-midi-input-devices)
+  (midi/list-devices)
+  (midi/list-input-devices)
 
-  (midi-device-debug "nanoKONTROL SLIDER/KNOB")
+  (midi/device-debug "nanoKONTROL SLIDER/KNOB")
 
-  (midi-device-debug "nanoKEY KEYBOARD")
-  (midi-device-debug "MPKmini2")
+  (midi/device-debug "nanoKEY KEYBOARD")
+  (midi/device-debug "MPKmini2")
   
   )

--- a/src/demo/pink/demo/midi_keys.clj
+++ b/src/demo/pink/demo/midi_keys.clj
@@ -1,6 +1,6 @@
 (ns pink.demo.midi-keys
   (:require [pink.simple :refer :all] 
-            [pink.io.midi :refer :all]
+            [pink.io.midi :as midi]
             [pink.config :refer :all]
             [pink.space :refer :all]
             [pink.oscillators :refer :all]
@@ -11,7 +11,7 @@
            [clojure.lang IFn]))
 
 
-(def midim (create-midi-manager))
+(def midim (midi/create-manager))
 (def keyboard (add-virtual-device midim "keyboard 1")) 
 
 (defn saw
@@ -31,9 +31,9 @@
 
 (comment
   ;(bind-device midim "nanoKEY KEYBOARD" "keyboard 1")
-  (bind-device midim "MPKmini2" "keyboard 1")
+  (midi/bind-device midim "VMidi 1" "keyboard 1")
 
-  (bind-key-func
+  (midi/bind-key-func
     keyboard 0
 
     (let  [allocator (create-max-allocator 8) 

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -89,11 +89,12 @@
 (defn find-midi-device [^String device-name device-type]
   (let [devices (list-midi-devices)
         found (filter 
-                #(and (>= (.indexOf ^String (:description %) device-name) 0) 
-                (if (= :in device-type)  
-                  (>= (.getMaxReceivers ^MidiDevice (:device %) ) 0)
-                  (>= (.getMaxTransmitters ^MidiDevice (:device %) ) 0)
-                  ))
+                #(and (or (>= (.indexOf ^String (:description %) device-name) 0)
+                          (>= (.indexOf ^String (:name %) device-name) 0)) 
+                      (if (= :in device-type)  
+                        (>= (.getMaxReceivers ^MidiDevice (:device %) ) 0)
+                        (>= (.getMaxTransmitters ^MidiDevice (:device %) ) 0)
+                        ))
                 devices)
 
         num-found (count found)]

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -89,12 +89,14 @@
 (defn find-midi-device [^String device-name device-type]
   (let [devices (list-midi-devices)
         found (filter 
-                #(and (or (>= (.indexOf ^String (:description %) device-name) 0)
-                          (>= (.indexOf ^String (:name %) device-name) 0)) 
-                      (if (= :in device-type)  
-                        (>= (.getMaxReceivers ^MidiDevice (:device %) ) 0)
-                        (>= (.getMaxTransmitters ^MidiDevice (:device %) ) 0)
-                        ))
+                (fn [{:keys [^String description 
+                             ^String name 
+                             ^MidiDevice device]}] 
+                  (and (or (>= (.indexOf description device-name) 0)
+                           (>= (.indexOf name device-name) 0)) 
+                       (if (= :in device-type)
+                         (>= (.getMaxReceivers device) 0)
+                         (>= (.getMaxTransmitters device) 0))))
                 devices)
 
         num-found (count found)]

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -96,17 +96,17 @@
                          (midi-input-device? device)
                          (midi-output-device? device))))
                 devices)
-
         num-found (count found)]
     (cond
       (<= num-found 0) 
-      (throw (Exception. (str "No MIDI devices found matching name: " device-name)))
+      (throw (Exception. (str "No MIDI " 
+                              ({:in "input" :out "output"} device-type) 
+                              " devices found matching name: " device-name)))
       (> num-found 1) 
-      (throw (->> found
-                  (map #(str "\t" (:name %) ": " (:description %) "\n"))
-                  (apply str "Multiple devices found (" num-found 
-                         ") matching name: " device-name "\n")
-                  Exception.))
+      (let [names (map #(str "\t" (:name %) ": " (:description %) "\n") found)
+            msg ^String (apply str "Multiple devices found (" num-found 
+                               ") matching name: " device-name "\n" names)] 
+        (throw (Exception. msg)))
       :else (first found))))
 
 

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -89,14 +89,12 @@
 (defn find-midi-device [^String device-name device-type]
   (let [devices (list-midi-devices)
         found (filter 
-                (fn [{:keys [^String description 
-                             ^String name 
-                             ^MidiDevice device]}] 
+                (fn [{:keys [^String description ^String name] :as device}] 
                   (and (or (>= (.indexOf description device-name) 0)
                            (>= (.indexOf name device-name) 0)) 
                        (if (= :in device-type)
-                         (>= (.getMaxReceivers device) 0)
-                         (>= (.getMaxTransmitters device) 0))))
+                         (midi-input-device? device)
+                         (midi-output-device? device))))
                 devices)
 
         num-found (count found)]
@@ -108,7 +106,7 @@
                   (map #(str "\t" (:name %) ": " (:description %) "\n"))
                   (apply str "Multiple devices found (" num-found 
                          ") matching name: " device-name "\n")
-                  Exception.)
+                  Exception.))
       :else (first found))))
 
 

--- a/src/main/pink/io/midi.clj
+++ b/src/main/pink/io/midi.clj
@@ -102,9 +102,13 @@
         num-found (count found)]
     (cond
       (<= num-found 0) 
-      (throw (Exception. "No devices found"))
+      (throw (Exception. (str "No MIDI devices found matching name: " device-name)))
       (> num-found 1) 
-      (throw (Exception. (format "Multiple devices found (%d)." num-found)))
+      (throw (->> found
+                  (map #(str "\t" (:name %) ": " (:description %) "\n"))
+                  (apply str "Multiple devices found (" num-found 
+                         ") matching name: " device-name "\n")
+                  Exception.)
       :else (first found))))
 
 


### PR DESCRIPTION
* Renamed fns to have more idiomatic naming in `pink.io.midi` namespace.
* Updated demo's that relied on this functionality.

Renaming described in Issue #5.

Note - this is branched from branch used in pull request #7.

This breaks several examples in music-examples repository which will need to be fixed should a new release be made.